### PR TITLE
Fix/6/zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wordpress plugin which add mutations to ACF Fields
 
 ### Install
 
-https://packagist.org/packages/zngly/wp-graphql-acf-mutations
+<https://packagist.org/packages/zngly/wp-graphql-acf-mutations>
 
 `composer require zngly/wp-graphql-acf-mutations`
 
@@ -26,6 +26,14 @@ If an acf type needs a specific graphql type such as a custom enum then specify
 ### Limitations
 
 Currently the mutations will not be set for objects nested with more than one child deep.
+
+### Zip Install
+
+1. Download the [Latest Release](https://github.com/zngly/wp-graphql-acf-mutations/releases)
+2. Extract the contents of the zip file into a folder `wp-graphql-acf-mutations`
+3. Place the `wp-graphql-acf-mutations` folder in your `wp-content/plugins` folder
+4. From `wp-content/plugins/wp-graphql-acf-mutations` directory run `composer install:prod`
+5. Activate the plugin
 
 ### Dev Usage
 

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         ]
     },
     "scripts": {
-        "install": "composer install --no-dev",
+        "install:prod": "composer install --no-dev",
         "install:dev": [
             "Zngly\\ACFM\\Scripts\\Install::run"
         ],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "zngly/wp-graphql-acf-mutations",
     "description": "ACF Mutations for WP GraphQL",
     "homepage": "https://github.com/zngly/wp-graphql-acf-mutations",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-graphql-acf-mutations",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "wp-graphql-acf-mutations",
     "homepage": "https://github.com/zngly/wp-graphql-acf-mutations#readme",
     "author": "Vlad-Anton Medves",

--- a/scripts/Watcher.php
+++ b/scripts/Watcher.php
@@ -19,12 +19,12 @@ class Watcher
         // get the directory to watch
         $src_folder = Utils::get_root_dir() . '/src';
 
-        // get all the files in the directory recursively
+        // get all the path to the main plugin file
         $plugin_name = Utils::get_plugin_name();
-        $plugin_folder = Utils::get_root_dir() . "/wordpress/wp-content/plugins/{$plugin_name}";
+        $main_plugin_file = Utils::get_root_dir() . "/{$plugin_name}.php";
 
         // watch for any file changes in the directory
-        self::watch_dirs([$src_folder,  "{$plugin_folder}/{$plugin_name}.php"]);
+        self::watch_dirs([$src_folder,  $main_plugin_file]);
     }
 
     // function to watch a directory for changes

--- a/wp-graphql-acf-mutations.php
+++ b/wp-graphql-acf-mutations.php
@@ -5,7 +5,7 @@
  * Description:       Adds Advanced Custom Fields Mutations to the WPGraphQL Schema
  * Author:            Vlad-Anton Medves
  * Text Domain:       wp-graphql-acf
- * Version:           1.0.5
+ * Version:           v1.1.1
  * Requires PHP:      7.0
  *
  * @package         WPGraphQL_ACF_Mutations

--- a/wp-graphql-acf-mutations.php
+++ b/wp-graphql-acf-mutations.php
@@ -18,10 +18,10 @@ if (!defined('ABSPATH')) {
 }
 
 // if namespace Zngly\ACFM is not defined
-if (!defined('ZNGLY_ACFM_NS')) {
+if (!class_exists('Zngly\\ACFM\\Mutations')) {
     // require the autoloader in wordpress/vendor/autoload.php
     // if the autoloader is not found, exit with an error message
-    if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+    if (!file_exists(__DIR__ . '/wordpress/vendor/autoload.php')) {
         wp_die(
             "
             <samp>
@@ -36,7 +36,7 @@ if (!defined('ZNGLY_ACFM_NS')) {
         );
     }
 
-    require_once __DIR__ . '/vendor/autoload.php';
+    require_once __DIR__ . '/wordpress/vendor/autoload.php';
 }
 
 /**

--- a/wp-graphql-acf-mutations.php
+++ b/wp-graphql-acf-mutations.php
@@ -17,6 +17,28 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// if namespace Zngly\ACFM is not defined
+if (!defined('ZNGLY_ACFM_NS')) {
+    // require the autoloader in wordpress/vendor/autoload.php
+    // if the autoloader is not found, exit with an error message
+    if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+        wp_die(
+            "
+            <samp>
+                Error: Could not load WPGraphQL ACF Mutations. Please install the WPGraphQL ACF Mutations plugin via Composer.
+            </samp>
+            <br>
+            <br>
+            <code>
+                composer install:prod
+            </code>
+            "
+        );
+    }
+
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
 /**
  * Define constants
  */


### PR DESCRIPTION
#6 

Addresses error when installing from zip file. 
There are clear instructions on how to install this plugin via zip. 

- fix: watcher -> watch correct file